### PR TITLE
dx(types): add types from DefinitelyTyped

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,52 @@
+declare namespace Mousetrap {
+	interface ExtendedKeyboardEvent extends KeyboardEvent {
+		returnValue: boolean; // IE returnValue
+	}
+
+	interface MousetrapStatic {
+		(el?: Element): MousetrapInstance;
+		new (el?: Element, useCapture?: boolean): MousetrapInstance;
+		addKeycodes(keycodes: { [key: number]: string }): void;
+		stopCallback: (
+			e: ExtendedKeyboardEvent,
+			element: Element,
+			combo: string,
+		) => boolean;
+		bind(
+			keys: string | string[],
+			// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+			callback: (e: ExtendedKeyboardEvent, combo: string) => boolean | void,
+			action?: string,
+		): MousetrapInstance;
+		unbind(keys: string | string[], action?: string): MousetrapInstance;
+		trigger(keys: string, action?: string): MousetrapInstance;
+		reset(): MousetrapInstance;
+	}
+
+	interface MousetrapInstance {
+		stopCallback: (
+			e: ExtendedKeyboardEvent,
+			element: Element,
+			combo: string,
+		) => boolean;
+		bind(
+			keys: string | string[],
+			callback: (e: ExtendedKeyboardEvent, combo: string) => void,
+			action?: string,
+		): this;
+		unbind(keys: string | string[], action?: string): this;
+		trigger(keys: string, action?: string): this;
+		handleKey(
+			character: string,
+			modifiers: string[],
+			e: ExtendedKeyboardEvent,
+		): void;
+		reset(): this;
+	}
+}
+
+declare const Mousetrap: Mousetrap.MousetrapStatic;
+
+export = Mousetrap;
+
+export as namespace Mousetrap;


### PR DESCRIPTION
The types are originally from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mousetrap and have been modified to allow for the second param for useCapture that was merged in the PR before.
