### PR TITLE
refac(useCapture): Make useCapture part of options param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,9 +3,13 @@ declare namespace Mousetrap {
 		returnValue: boolean; // IE returnValue
 	}
 
+	interface MousetrapOpts {
+		useCapture: boolean;
+	}
+
 	interface MousetrapStatic {
 		(el?: Element): MousetrapInstance;
-		new (el?: Element, useCapture?: boolean): MousetrapInstance;
+		new (el?: Element, opts?: MousetrapOpts): MousetrapInstance;
 		addKeycodes(keycodes: { [key: number]: string }): void;
 		stopCallback: (
 			e: ExtendedKeyboardEvent,

--- a/mousetrap.js
+++ b/mousetrap.js
@@ -432,7 +432,7 @@
         return _belongsTo(element.parentNode, ancestor);
     }
 
-    function Mousetrap(targetElement, useCapture) {
+    function Mousetrap(targetElement, {useCapture}) {
         var self = this;
 
         targetElement = targetElement || document;


### PR DESCRIPTION
Currently the useCapture param is a meaningless literal in caller code. Making it an option param makes the code more readable.
