### PR TITLE
fix(opts): Make opts and useCapture optional in js

### DIFF
--- a/mousetrap.js
+++ b/mousetrap.js
@@ -432,7 +432,7 @@
         return _belongsTo(element.parentNode, ancestor);
     }
 
-    function Mousetrap(targetElement, {useCapture}) {
+    function Mousetrap(targetElement, {useCapture = false} = {}) {
         var self = this;
 
         targetElement = targetElement || document;


### PR DESCRIPTION
The param wasn't optional, this makes it optional and also defaults the useCapture param to false.