### PR TITLE
license: add MIT license for type definitions

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,5 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) Dániel Tar, Alan Choi, Nic Barker, Piotr Błażejewicz and other contributors
+// (Listed as owners in the DefinitelyTyped package metadata)
+//
+// This file is licensed under the MIT License.
+// A copy of the license text can be found in the LICENSE-MIT file.
+// All other files in the repository are licensed under the Apache 2.0 License
+// which can be found in the LICENSE file.
+
 declare namespace Mousetrap {
 	interface ExtendedKeyboardEvent extends KeyboardEvent {
 		returnValue: boolean; // IE returnValue


### PR DESCRIPTION
Before making the repository public we need to include the license and copyright notice for the type definitions.
